### PR TITLE
feat: implement MainTabView for primary navigation

### DIFF
--- a/iExpensesTracker/iExpensesTracker/Views/App/MainTabView.swift
+++ b/iExpensesTracker/iExpensesTracker/Views/App/MainTabView.swift
@@ -1,0 +1,42 @@
+//
+//  MainTabView.swift
+//  iExpensesTracker
+//
+//  Created by Alejandro isai Acosta Martinez on 10/03/25.
+//
+
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            // Home
+            HomeView()
+                .tabItem {
+                    Image(systemName: "house.fill")
+                    Text("Home")
+                }
+
+            // Expenses
+            ExpensesView()
+                .tabItem {
+                    Image(systemName: "list.bullet")
+                    Text("Expenses")
+                }
+
+            // Profile
+            ProfileView()
+                .tabItem {
+                    Image(systemName: "person.circle.fill")
+                    Text("Profile")
+                }
+        }
+        .tint(.iETPrimaryGreen)
+    }
+}
+
+struct MainTabView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainTabView()
+    }
+}

--- a/iExpensesTracker/iExpensesTracker/Views/Expenses/ExpensesView.swift
+++ b/iExpensesTracker/iExpensesTracker/Views/Expenses/ExpensesView.swift
@@ -1,0 +1,26 @@
+
+//
+//  Untitled.swift
+//  iExpensesTracker
+//
+//  Created by Alejandro isai Acosta Martinez on 10/03/25.
+//
+
+import SwiftUI
+
+struct ExpensesView: View {
+    var body: some View {
+        ZStack {
+            Color.iETLightBackground.ignoresSafeArea()
+            Text("Expenses")
+                .font(.title)
+                .foregroundColor(.iETPrimaryGreen)
+        }
+    }
+}
+
+struct ExpensesView_Previews: PreviewProvider {
+    static var previews: some View {
+        ExpensesView()
+    }
+}

--- a/iExpensesTracker/iExpensesTracker/Views/Home/HomeView.swift
+++ b/iExpensesTracker/iExpensesTracker/Views/Home/HomeView.swift
@@ -1,0 +1,25 @@
+//
+//  HomeView.swift
+//  iExpensesTracker
+//
+//  Created by Alejandro isai Acosta Martinez on 10/03/25.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        ZStack {
+            Color.iETLightBackground.ignoresSafeArea()
+            Text("Home")
+                .font(.title)
+                .foregroundColor(.iETPrimaryGreen)
+        }
+    }
+}
+
+struct HomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeView()
+    }
+}

--- a/iExpensesTracker/iExpensesTracker/Views/Profile/ProfileView.swift
+++ b/iExpensesTracker/iExpensesTracker/Views/Profile/ProfileView.swift
@@ -1,0 +1,25 @@
+//
+//  ProfileView.swift
+//  iExpensesTracker
+//
+//  Created by Alejandro isai Acosta Martinez on 10/03/25.
+//
+
+import SwiftUI
+
+struct ProfileView: View {
+    var body: some View {
+        ZStack {
+            Color.iETLightBackground.ignoresSafeArea()
+            Text("Profile")
+                .font(.title)
+                .foregroundColor(.iETPrimaryGreen)
+        }
+    }
+}
+
+struct ProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileView()
+    }
+}

--- a/iExpensesTracker/iExpensesTracker/iExpensesTrackerApp.swift
+++ b/iExpensesTracker/iExpensesTracker/iExpensesTrackerApp.swift
@@ -29,7 +29,7 @@ struct iExpensesTrackerApp: App {
     var body: some Scene {
         WindowGroup {
             if authViewModel.isUserLoggedIn {
-                ContentView()
+                MainTabView()
                     .preferredColorScheme(.light)
             } else {
                 LoginView()


### PR DESCRIPTION
## Summary
This PR introduces a `MainTabView` with three tabs: Home, Expenses, and Profile. 
Each tab currently displays a simple screen with a label at the center.

### Main Changes
- **MainTabView**: SwiftUI TabView structure for the app
- **HomeView**, **ExpensesView**, **ProfileView**: Minimal initial views, ready for further development

### Next Steps
- Merge into `develop`
- Expand each view with actual content (charts, expense list, user profile, etc.)
